### PR TITLE
Use Bedrock for credit scoring backend

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,15 +1,25 @@
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
-from openai import OpenAI
+import boto3
+import json
 import os
 from dotenv import load_dotenv
 from pymongo import MongoClient
-# from openai.embeddings_utils import get_embedding
 
 load_dotenv()
 
-client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+AWS_REGION = os.getenv("AWS_REGION")
+TEXT_MODEL_ID = os.getenv("BEDROCK_TEXT_MODEL_ID")
+EMBED_MODEL_ID = os.getenv("BEDROCK_EMBED_MODEL_ID")
+
+bedrock_client = boto3.client(
+    "bedrock-runtime",
+    region_name=AWS_REGION,
+    aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
+    aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
+    aws_session_token=os.getenv("AWS_SESSION_TOKEN"),
+)
 mongo_client = MongoClient(os.getenv("MONGODB_URI"))
 db = mongo_client["bfsi-genai"]
 collection = db["user_profiles"]
@@ -69,15 +79,25 @@ def score_credit(input: CreditInput):
         """
 
         try:
-            gpt_response = client.chat.completions.create(
-                model="gpt-4",
-                messages=[
-                    {"role": "system", "content": "You are a credit analyst helping users understand their credit risk."},
-                    {"role": "user", "content": summary_prompt}
-                ],
-                max_tokens=200
+            body = json.dumps(
+                {
+                    "anthropic_version": "bedrock-2023-05-31",
+                    "max_tokens": 200,
+                    "system": "You are a credit analyst helping users understand their credit risk.",
+                    "messages": [{"role": "user", "content": summary_prompt}],
+                }
             )
-            explanation = gpt_response.choices[0].message.content.strip()
+            response = bedrock_client.invoke_model(
+                modelId=TEXT_MODEL_ID,
+                contentType="application/json",
+                accept="application/json",
+                body=body,
+            )
+            status_code = response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+            if status_code != 200:
+                raise Exception(f"Bedrock invocation failed with status code {status_code}")
+            response_body = json.loads(response["body"].read())
+            explanation = response_body["content"][0]["text"].strip()
         except Exception as e:
             explanation = f"LLM summary failed: {str(e)}"
 
@@ -117,7 +137,20 @@ def score_credit(input: CreditInput):
 @app.post("/similar_products")
 def similar_products(query: QueryDescription):
     try:
-        embedding = client.embeddings.create(input=query.description, model="text-embedding-ada-002").data[0].embedding
+        embed_body = json.dumps({"inputText": query.description})
+        response = bedrock_client.invoke_model(
+            modelId=EMBED_MODEL_ID,
+            contentType="application/json",
+            accept="application/json",
+            body=embed_body,
+        )
+        status_code = response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+        if status_code != 200:
+            raise Exception(f"Bedrock invocation failed with status code {status_code}")
+        response_body = json.loads(response["body"].read())
+        embedding = response_body.get("embedding")
+        if embedding is None:
+            raise Exception("No embedding returned from Bedrock")
 
         results = products.aggregate([
             {
@@ -142,3 +175,4 @@ def similar_products(query: QueryDescription):
         return {"results": list(results)}
     except Exception as e:
         return {"error": f"Vector search failed: {str(e)}"}
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,5 @@
 fastapi
 uvicorn
-openai
+boto3
 pydantic
 python-dotenv


### PR DESCRIPTION
## Summary
- replace OpenAI usage with AWS Bedrock runtime client
- load AWS region, credentials, and model IDs from environment variables
- handle Bedrock text and embedding invocations with explicit error checks
- add boto3 dependency

## Testing
- `python -m py_compile backend/main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68942e7f3f8c83228668069a656c951f