### PR TITLE
Use raw string for SSN regex to avoid SyntaxWarning

### DIFF
--- a/rule_based_screening_rules.json
+++ b/rule_based_screening_rules.json
@@ -12,7 +12,7 @@
         {
           "name": "SSN/ID Format Validation",
           "description": "Ensure SSN follows the format XXX-XX-XXXX",
-          "condition": "not matches_regex(ssn, '^\\d{3}-\\d{2}-\\d{4}$')",
+          "condition": "not matches_regex(ssn, r'^\\d{3}-\\d{2}-\\d{4}$')",
           "action": "reject"
         },
         {


### PR DESCRIPTION
## Summary
- prevent escape sequence warnings for SSN format rule by using a raw string pattern

## Testing
- `pytest`
- `python - <<'PY'
import sys
sys.path.append('backend')
import validators
import warnings
warnings.filterwarnings('default')
validators.load_rules.cache_clear()
rules = validators.load_rules()
print(rules[0]['rules'][1]['condition'])
res = validators.evaluate_rules({'ssn': '123-45-6789', 'age':20})
print(res)
PY`


------
https://chatgpt.com/codex/tasks/task_e_6895759863b48322ab5242561ed6b2b9