### PR TITLE
Handle rejected or flagged credit score responses

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -34,6 +34,12 @@ export default function CreditScoringApp() {
     try {
       const res = await axios.post('http://localhost:8000/score', formData);
       const result = res.data;
+      if (result.status === 'rejected' || result.status === 'flagged') {
+        const reason = result.description || result.reason || (result.flags ? result.flags.join(', ') : 'No details provided');
+        alert(`${result.status === 'rejected' ? 'Application rejected' : 'Application flagged'}: ${reason}`);
+        return;
+      }
+
       setCreditScore(result.credit_score_estimate);
       setAnomalyScore(result.anomaly_score ?? result.fraud_risk ?? null);
       setScoreBreakdown({


### PR DESCRIPTION
## Summary
- Check backend response status before using credit score
- Alert users with rejection or flag reasons instead of reading missing credit score data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68957d677d788322882c828a3f55ee12