### PR TITLE
Include SSN in backend and compute missing fields

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -4,8 +4,6 @@ from pydantic import BaseModel
 import boto3
 import json
 import os
-import json
-import boto3
 from dotenv import load_dotenv
 from pymongo import MongoClient
 from validators import evaluate_rules
@@ -39,6 +37,7 @@ def read_root():
 
 class CreditInput(BaseModel):
     Name: str
+    ssn: str
     Age: str
     Occupation: str
     Annual_Income: str
@@ -97,7 +96,9 @@ def invoke_scoring_service(profile: dict, service: str = os.getenv("MODEL_SERVIC
 @app.post("/score")
 def score_credit(input: CreditInput):
     profile = input.dict()
+    profile["missing_fields"] = [k for k, v in profile.items() if v in (None, "")]
     screening = evaluate_rules(profile)
+    profile.pop("missing_fields", None)
     if screening["status"] == "reject":
         return {
             "status": "rejected",


### PR DESCRIPTION
## Summary
- add `ssn` field to `CreditInput` so rule engine can validate SSN
- compute and remove `missing_fields` before screening
- drop duplicate imports in backend

## Testing
- `cd backend && pytest`
- `cd ../frontend && npm test >/tmp/npm-test.log && tail -n 20 /tmp/npm-test.log`


------
https://chatgpt.com/codex/tasks/task_e_689578c7a7788322963bb2237ee38d5d