### PR TITLE
Add inference profile support for Bedrock calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,13 @@ AWS_SECRET_ACCESS_KEY=your-secret-key
 AWS_REGION=us-east-1
 ```
 
-2. Enable [Amazon Bedrock](https://aws.amazon.com/bedrock/) and choose a model:
+2. Enable [Amazon Bedrock](https://aws.amazon.com/bedrock/) and choose models and, if required, their inference profiles:
 
 ```bash
-BEDROCK_MODEL_ID=anthropic.claude-v2
+BEDROCK_TEXT_MODEL_ID=anthropic.claude-v2
+BEDROCK_TEXT_INFERENCE_PROFILE_ARN=arn:aws:bedrock:REGION:ACCOUNT_ID:inference-profile/my-text-profile
+BEDROCK_EMBED_MODEL_ID=amazon.titan-embed-text-v1
+BEDROCK_EMBED_INFERENCE_PROFILE_ARN=arn:aws:bedrock:REGION:ACCOUNT_ID:inference-profile/my-embed-profile
 ```
 
 3. Deploy an anomaly detection service using [AWS Fraud Detector](https://aws.amazon.com/fraud-detector/) or a [SageMaker](https://aws.amazon.com/sagemaker/) endpoint and capture its identifier:

--- a/backend/README.md
+++ b/backend/README.md
@@ -28,7 +28,10 @@ User Input → React UI → FastAPI (/score) → Rule-based scoring + Bedrock LL
 AWS_ACCESS_KEY_ID=your-access-key
 AWS_SECRET_ACCESS_KEY=your-secret-key
 AWS_REGION=us-east-1
-BEDROCK_MODEL_ID=anthropic.claude-v2
+BEDROCK_TEXT_MODEL_ID=anthropic.claude-v2
+BEDROCK_TEXT_INFERENCE_PROFILE_ARN=arn:aws:bedrock:REGION:ACCOUNT_ID:inference-profile/my-text-profile
+BEDROCK_EMBED_MODEL_ID=amazon.titan-embed-text-v1
+BEDROCK_EMBED_INFERENCE_PROFILE_ARN=arn:aws:bedrock:REGION:ACCOUNT_ID:inference-profile/my-embed-profile
 FRAUD_DETECTOR_MODEL_ARN=arn:aws:frauddetector:us-east-1:123456789012:detector/my-detector   # if using Fraud Detector
 SAGEMAKER_ENDPOINT_NAME=my-anomaly-endpoint                                                   # if using SageMaker
 MONGODB_URI=mongodb://localhost:27017


### PR DESCRIPTION
## Summary
- allow configuring Bedrock text and embedding models via optional inference profile ARNs
- document new inference profile environment variables for backend and root setup

## Testing
- `python -m py_compile backend/main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68958704ae108322951963378f181352