### PR TITLE
Use inference profiles for Bedrock model invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,21 @@ AWS_SECRET_ACCESS_KEY=your-secret-key
 AWS_REGION=us-east-1
 ```
 
-2. Enable [Amazon Bedrock](https://aws.amazon.com/bedrock/) and choose models and, if required, their inference profiles:
+2. Enable [Amazon Bedrock](https://aws.amazon.com/bedrock/) and choose models or, if required, their inference profiles:
 
 ```bash
+# For on-demand models
 BEDROCK_TEXT_MODEL_ID=anthropic.claude-v2
+
+# For models that require an inference profile, omit BEDROCK_TEXT_MODEL_ID and set one of:
 BEDROCK_TEXT_INFERENCE_PROFILE_ARN=arn:aws:bedrock:REGION:ACCOUNT_ID:inference-profile/my-text-profile
+BEDROCK_TEXT_INFERENCE_PROFILE_ID=ip-1234567890abcdef
+
 BEDROCK_EMBED_MODEL_ID=amazon.titan-embed-text-v1
 BEDROCK_EMBED_INFERENCE_PROFILE_ARN=arn:aws:bedrock:REGION:ACCOUNT_ID:inference-profile/my-embed-profile
 ```
+
+When an inference profile environment variable is provided, the backend uses it and does not send the `modelId` in the Bedrock request.
 
 3. Deploy an anomaly detection service using [AWS Fraud Detector](https://aws.amazon.com/fraud-detector/) or a [SageMaker](https://aws.amazon.com/sagemaker/) endpoint and capture its identifier:
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -28,14 +28,22 @@ User Input → React UI → FastAPI (/score) → Rule-based scoring + Bedrock LL
 AWS_ACCESS_KEY_ID=your-access-key
 AWS_SECRET_ACCESS_KEY=your-secret-key
 AWS_REGION=us-east-1
+
+# For on-demand models
 BEDROCK_TEXT_MODEL_ID=anthropic.claude-v2
+
+# For models requiring an inference profile, omit BEDROCK_TEXT_MODEL_ID and set one of:
 BEDROCK_TEXT_INFERENCE_PROFILE_ARN=arn:aws:bedrock:REGION:ACCOUNT_ID:inference-profile/my-text-profile
+BEDROCK_TEXT_INFERENCE_PROFILE_ID=ip-1234567890abcdef
+
 BEDROCK_EMBED_MODEL_ID=amazon.titan-embed-text-v1
 BEDROCK_EMBED_INFERENCE_PROFILE_ARN=arn:aws:bedrock:REGION:ACCOUNT_ID:inference-profile/my-embed-profile
 FRAUD_DETECTOR_MODEL_ARN=arn:aws:frauddetector:us-east-1:123456789012:detector/my-detector   # if using Fraud Detector
 SAGEMAKER_ENDPOINT_NAME=my-anomaly-endpoint                                                   # if using SageMaker
 MONGODB_URI=mongodb://localhost:27017
 ```
+
+The backend will invoke Bedrock through the configured inference profile when the corresponding environment variable is set.
 
 Ensure the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) is configured or the above variables are exported.
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -141,20 +141,17 @@ def score_credit(input: CreditInput):
                 "contentType": "application/json",
                 "accept": "application/json",
                 "body": body,
-                "modelId": TEXT_MODEL_ID,
             }
             operation = bedrock_client.meta.service_model.operation_model("InvokeModel")
             members = operation.input_shape.members
-            if "inferenceProfileArn" in members and TEXT_INFERENCE_PROFILE_ARN:
+            if TEXT_INFERENCE_PROFILE_ARN and "inferenceProfileArn" in members:
                 invoke_kwargs["inferenceProfileArn"] = TEXT_INFERENCE_PROFILE_ARN
-            elif "inferenceProfileId" in members and TEXT_INFERENCE_PROFILE_ID:
+            elif TEXT_INFERENCE_PROFILE_ID and "inferenceProfileId" in members:
                 invoke_kwargs["inferenceProfileId"] = TEXT_INFERENCE_PROFILE_ID
-
-            if (
-                TEXT_INFERENCE_PROFILE_ARN
-                and "inferenceProfileArn" in operation.input_shape.members
-            ):
-                invoke_kwargs["inferenceProfileArn"] = TEXT_INFERENCE_PROFILE_ARN
+            elif TEXT_MODEL_ID:
+                invoke_kwargs["modelId"] = TEXT_MODEL_ID
+            else:
+                raise Exception("Bedrock model or inference profile not configured")
             response = bedrock_client.invoke_model(**invoke_kwargs)
             status_code = response.get("ResponseMetadata", {}).get("HTTPStatusCode")
             if status_code != 200:
@@ -221,20 +218,17 @@ def similar_products(query: QueryDescription):
             "contentType": "application/json",
             "accept": "application/json",
             "body": body,
-            "modelId": TEXT_MODEL_ID,
         }
         operation = bedrock_client.meta.service_model.operation_model("InvokeModel")
         members = operation.input_shape.members
-        if "inferenceProfileArn" in members and TEXT_INFERENCE_PROFILE_ARN:
+        if TEXT_INFERENCE_PROFILE_ARN and "inferenceProfileArn" in members:
             invoke_kwargs["inferenceProfileArn"] = TEXT_INFERENCE_PROFILE_ARN
-        elif "inferenceProfileId" in members and TEXT_INFERENCE_PROFILE_ID:
+        elif TEXT_INFERENCE_PROFILE_ID and "inferenceProfileId" in members:
             invoke_kwargs["inferenceProfileId"] = TEXT_INFERENCE_PROFILE_ID
-
-        if (
-            TEXT_INFERENCE_PROFILE_ARN
-            and "inferenceProfileArn" in operation.input_shape.members
-        ):
-            invoke_kwargs["inferenceProfileArn"] = TEXT_INFERENCE_PROFILE_ARN
+        elif TEXT_MODEL_ID:
+            invoke_kwargs["modelId"] = TEXT_MODEL_ID
+        else:
+            raise Exception("Bedrock model or inference profile not configured")
 
         response = bedrock_client.invoke_model(**invoke_kwargs)
         status_code = response.get("ResponseMetadata", {}).get("HTTPStatusCode")


### PR DESCRIPTION
## Summary
- invoke Amazon Bedrock with inference profile ARN/ID when provided instead of always sending modelId
- document environment variables for inference profile usage and when to omit modelId

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68959f9c8128832296aba0c767572403