### PR TITLE
Use cross-region inference for Bedrock model invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,22 @@ AWS_SECRET_ACCESS_KEY=your-secret-key
 AWS_REGION=us-east-1
 ```
 
-2. Enable [Amazon Bedrock](https://aws.amazon.com/bedrock/) and choose models and, if required, their inference profiles:
+2. Enable [Amazon Bedrock](https://aws.amazon.com/bedrock/) and configure cross-region inference with an inference profile:
 
 ```bash
-BEDROCK_TEXT_MODEL_ID=anthropic.claude-v2
-BEDROCK_TEXT_INFERENCE_PROFILE_ARN=arn:aws:bedrock:REGION:ACCOUNT_ID:inference-profile/my-text-profile
-BEDROCK_EMBED_MODEL_ID=amazon.titan-embed-text-v1
-BEDROCK_EMBED_INFERENCE_PROFILE_ARN=arn:aws:bedrock:REGION:ACCOUNT_ID:inference-profile/my-embed-profile
+# Region hosting the text inference profile
+BEDROCK_TEXT_REGION=us-west-2
+
+# Provide one of the following for the profile
+BEDROCK_TEXT_INFERENCE_PROFILE_ARN=arn:aws:bedrock:us-west-2:ACCOUNT_ID:inference-profile/my-text-profile
+BEDROCK_TEXT_INFERENCE_PROFILE_ID=ip-1234567890abcdef
+
+# Optional embedding profile
+BEDROCK_EMBED_REGION=us-west-2
+BEDROCK_EMBED_INFERENCE_PROFILE_ARN=arn:aws:bedrock:us-west-2:ACCOUNT_ID:inference-profile/my-embed-profile
 ```
+
+When an inference profile variable is set, the backend uses cross-region inference and omits the `modelId` in Bedrock requests.
 
 3. Deploy an anomaly detection service using [AWS Fraud Detector](https://aws.amazon.com/fraud-detector/) or a [SageMaker](https://aws.amazon.com/sagemaker/) endpoint and capture its identifier:
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -28,14 +28,23 @@ User Input → React UI → FastAPI (/score) → Rule-based scoring + Bedrock LL
 AWS_ACCESS_KEY_ID=your-access-key
 AWS_SECRET_ACCESS_KEY=your-secret-key
 AWS_REGION=us-east-1
-BEDROCK_TEXT_MODEL_ID=anthropic.claude-v2
-BEDROCK_TEXT_INFERENCE_PROFILE_ARN=arn:aws:bedrock:REGION:ACCOUNT_ID:inference-profile/my-text-profile
-BEDROCK_EMBED_MODEL_ID=amazon.titan-embed-text-v1
-BEDROCK_EMBED_INFERENCE_PROFILE_ARN=arn:aws:bedrock:REGION:ACCOUNT_ID:inference-profile/my-embed-profile
+
+# Region hosting the text inference profile
+BEDROCK_TEXT_REGION=us-west-2
+
+# Provide one of the following for the profile
+BEDROCK_TEXT_INFERENCE_PROFILE_ARN=arn:aws:bedrock:us-west-2:ACCOUNT_ID:inference-profile/my-text-profile
+BEDROCK_TEXT_INFERENCE_PROFILE_ID=ip-1234567890abcdef
+
+# Optional embedding profile
+BEDROCK_EMBED_REGION=us-west-2
+BEDROCK_EMBED_INFERENCE_PROFILE_ARN=arn:aws:bedrock:us-west-2:ACCOUNT_ID:inference-profile/my-embed-profile
 FRAUD_DETECTOR_MODEL_ARN=arn:aws:frauddetector:us-east-1:123456789012:detector/my-detector   # if using Fraud Detector
 SAGEMAKER_ENDPOINT_NAME=my-anomaly-endpoint                                                   # if using SageMaker
 MONGODB_URI=mongodb://localhost:27017
 ```
+
+The backend uses cross-region inference through the configured inference profile and omits any `modelId` from requests.
 
 Ensure the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) is configured or the above variables are exported.
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -11,7 +11,7 @@ from validators import evaluate_rules
 load_dotenv()
 
 AWS_REGION = os.getenv("AWS_REGION")
-TEXT_MODEL_ID = os.getenv("BEDROCK_TEXT_MODEL_ID")
+TEXT_REGION = os.getenv("BEDROCK_TEXT_REGION")
 TEXT_INFERENCE_PROFILE_ARN = os.getenv("BEDROCK_TEXT_INFERENCE_PROFILE_ARN")
 TEXT_INFERENCE_PROFILE_ID = os.getenv("BEDROCK_TEXT_INFERENCE_PROFILE_ID")
 
@@ -141,20 +141,17 @@ def score_credit(input: CreditInput):
                 "contentType": "application/json",
                 "accept": "application/json",
                 "body": body,
-                "modelId": TEXT_MODEL_ID,
             }
             operation = bedrock_client.meta.service_model.operation_model("InvokeModel")
             members = operation.input_shape.members
-            if "inferenceProfileArn" in members and TEXT_INFERENCE_PROFILE_ARN:
+            if TEXT_INFERENCE_PROFILE_ARN and "inferenceProfileArn" in members:
                 invoke_kwargs["inferenceProfileArn"] = TEXT_INFERENCE_PROFILE_ARN
-            elif "inferenceProfileId" in members and TEXT_INFERENCE_PROFILE_ID:
+            elif TEXT_INFERENCE_PROFILE_ID and "inferenceProfileId" in members:
                 invoke_kwargs["inferenceProfileId"] = TEXT_INFERENCE_PROFILE_ID
-
-            if (
-                TEXT_INFERENCE_PROFILE_ARN
-                and "inferenceProfileArn" in operation.input_shape.members
-            ):
-                invoke_kwargs["inferenceProfileArn"] = TEXT_INFERENCE_PROFILE_ARN
+            else:
+                raise Exception("Bedrock inference profile not configured")
+            if TEXT_REGION and "targetModelRegion" in members:
+                invoke_kwargs["targetModelRegion"] = TEXT_REGION
             response = bedrock_client.invoke_model(**invoke_kwargs)
             status_code = response.get("ResponseMetadata", {}).get("HTTPStatusCode")
             if status_code != 200:
@@ -221,20 +218,17 @@ def similar_products(query: QueryDescription):
             "contentType": "application/json",
             "accept": "application/json",
             "body": body,
-            "modelId": TEXT_MODEL_ID,
         }
         operation = bedrock_client.meta.service_model.operation_model("InvokeModel")
         members = operation.input_shape.members
-        if "inferenceProfileArn" in members and TEXT_INFERENCE_PROFILE_ARN:
+        if TEXT_INFERENCE_PROFILE_ARN and "inferenceProfileArn" in members:
             invoke_kwargs["inferenceProfileArn"] = TEXT_INFERENCE_PROFILE_ARN
-        elif "inferenceProfileId" in members and TEXT_INFERENCE_PROFILE_ID:
+        elif TEXT_INFERENCE_PROFILE_ID and "inferenceProfileId" in members:
             invoke_kwargs["inferenceProfileId"] = TEXT_INFERENCE_PROFILE_ID
-
-        if (
-            TEXT_INFERENCE_PROFILE_ARN
-            and "inferenceProfileArn" in operation.input_shape.members
-        ):
-            invoke_kwargs["inferenceProfileArn"] = TEXT_INFERENCE_PROFILE_ARN
+        else:
+            raise Exception("Bedrock inference profile not configured")
+        if TEXT_REGION and "targetModelRegion" in members:
+            invoke_kwargs["targetModelRegion"] = TEXT_REGION
 
         response = bedrock_client.invoke_model(**invoke_kwargs)
         status_code = response.get("ResponseMetadata", {}).get("HTTPStatusCode")


### PR DESCRIPTION
## Summary
- configure backend to invoke Bedrock through a cross-region inference profile and pass target model region when provided
- document BEDROCK_TEXT_REGION and inference profile variables for cross-region inference in project and backend READMEs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68959f9c8128832296aba0c767572403