### PR TITLE
refactor: use BedrockInvoker in backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,9 +3,9 @@ AWS_REGION=us-west-2
 AWS_PROFILE=
 
 # === Bedrock (LLM) config ===
-# If you use an on-demand model that supports direct invocation, set BEDROCK_TEXT_MODEL_ID.
-# For Claude 3.5 Haiku (and similar models that require inference profiles),
-# leave BEDROCK_TEXT_MODEL_ID empty and set one of the inference profile vars below.
+# Set BEDROCK_TEXT_MODEL_ID to the model you want to invoke. For models that
+# require inference profiles (e.g., Claude 3.5 Haiku) you must set both
+# BEDROCK_TEXT_MODEL_ID and one of the inference profile variables below.
 BEDROCK_TEXT_MODEL_ID=
 
 # Use ONE of these for Claude 3.5 Haiku cross-region profile:
@@ -16,3 +16,6 @@ BEDROCK_TEXT_INFERENCE_PROFILE_ARN=
 
 # Target model region for cross-region inference (e.g., where Claude 3.5 runs)
 BEDROCK_TEXT_REGION=us-west-2
+
+# Optional API key for direct Bedrock invocation
+BEDROCK_API_KEY=

--- a/src/llm/bedrock_runtime.py
+++ b/src/llm/bedrock_runtime.py
@@ -1,9 +1,11 @@
 import json
 import os
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, Set
+from urllib.parse import quote
 
 import boto3
 from botocore.config import Config
+import requests
 
 ANTHROPIC_VERSION = "bedrock-2023-05-31"
 
@@ -19,27 +21,31 @@ class BedrockInvoker:
         self,
         aws_region: Optional[str] = None,
         timeout_sec: int = 60,
+        api_key: Optional[str] = None,
     ):
         self.aws_region = aws_region or os.getenv("AWS_REGION", "us-west-2")
-        self.bedrock = boto3.client(
-            "bedrock-runtime",
-            region_name=self.aws_region,
-            config=Config(read_timeout=timeout_sec, retries={"max_attempts": 3}),
-        )
+        self.api_key = api_key or os.getenv("BEDROCK_API_KEY")
+        self.bedrock = None
+        self._params_supported: Set[str] = set()
+        if not self.api_key:
+            self.bedrock = boto3.client(
+                "bedrock-runtime",
+                region_name=self.aws_region,
+                config=Config(read_timeout=timeout_sec, retries={"max_attempts": 3}),
+            )
+            op = self.bedrock.meta.service_model.operation_model("InvokeModel")
+            self._params_supported = set(op.input_shape.members.keys())
         # Env-driven configuration
         self.model_id = os.getenv("BEDROCK_TEXT_MODEL_ID", "").strip()
         self.profile_id = os.getenv("BEDROCK_TEXT_INFERENCE_PROFILE_ID", "").strip()
         self.profile_arn = os.getenv("BEDROCK_TEXT_INFERENCE_PROFILE_ARN", "").strip()
         self.target_model_region = os.getenv("BEDROCK_TEXT_REGION", "").strip()
 
-        # Detect available parameters in current SDK
-        op = self.bedrock.meta.service_model.operation_model("InvokeModel")
-        self._params_supported = set(op.input_shape.members.keys())
-
     def _build_invoke_kwargs(self, body_json: str) -> Dict[str, Any]:
         """
         Build kwargs for bedrock.invoke_model() choosing profile ARN/ID first,
-        then falling back to modelId if no profile configured.
+        but always include modelId so the runtime knows which model to invoke.
+        Falls back to modelId alone if no profile is configured.
         """
         kwargs: Dict[str, Any] = {
             "contentType": "application/json",
@@ -47,18 +53,39 @@ class BedrockInvoker:
             "body": body_json,
         }
 
-        # Prefer inference profile (ARN > ID) when provided
-        if self.profile_arn:
+        # Prefer inference profile (ARN > ID) when provided.  However, some
+        # boto3 versions do not yet expose these parameters in the Runtime
+        # client.  When inference profiles are requested but not supported,
+        # fall back to a direct modelId if available, otherwise raise a clear
+        # error rather than invoking the API with missing parameters.
+        if self.profile_arn and "inferenceProfileArn" in self._params_supported:
+            if not self.model_id:
+                raise RuntimeError(
+                    "BEDROCK_TEXT_MODEL_ID must be set when using an inference profile."
+                )
             kwargs["inferenceProfileArn"] = self.profile_arn
-        elif self.profile_id:
-            kwargs["inferenceProfileId"] = self.profile_id
-        elif self.model_id:
-            # Fallback: on-demand modelId (only if profile not set)
             kwargs["modelId"] = self.model_id
+        elif self.profile_id and "inferenceProfileId" in self._params_supported:
+            if not self.model_id:
+                raise RuntimeError(
+                    "BEDROCK_TEXT_MODEL_ID must be set when using an inference profile."
+                )
+            kwargs["inferenceProfileId"] = self.profile_id
+            kwargs["modelId"] = self.model_id
+        elif self.model_id:
+            # Either no profile configured or the SDK doesn't support it; use
+            # the modelId directly.
+            kwargs["modelId"] = self.model_id
+        elif self.profile_id or self.profile_arn:
+            raise RuntimeError(
+                "The installed boto3 does not support Bedrock inference profiles. "
+                "Set BEDROCK_TEXT_MODEL_ID or provide BEDROCK_API_KEY to call the profile."
+            )
         else:
             raise RuntimeError(
-                "Bedrock not configured: set BEDROCK_TEXT_INFERENCE_PROFILE_ID (or ARN) "
-                "for Claude 3.5 Haiku, or BEDROCK_TEXT_MODEL_ID for on-demand models."
+                "Bedrock not configured: set BEDROCK_TEXT_MODEL_ID and an "
+                "inference profile for Claude 3.5 Haiku, or BEDROCK_TEXT_MODEL_ID "
+                "alone for on-demand models."
             )
 
         # Optional cross-region target if provided
@@ -91,6 +118,54 @@ class BedrockInvoker:
             payload.update(extra)
 
         body_json = json.dumps(payload)
+        if self.api_key:
+            # Prefer an inference profile (ARN or ID) when available for higher
+            # throughput before falling back to a direct model invocation.
+            if self.profile_arn:
+                if not self.model_id:
+                    raise RuntimeError(
+                        "BEDROCK_TEXT_MODEL_ID must be set when using an inference profile."
+                    )
+                identifier = quote(self.profile_arn, safe="")
+                model = quote(self.model_id, safe="")
+                url = (
+                    f"https://bedrock-runtime.{self.aws_region}.amazonaws.com/"
+                    f"inference-profiles/{identifier}/model/{model}/invoke"
+                )
+            elif self.profile_id:
+                if not self.model_id:
+                    raise RuntimeError(
+                        "BEDROCK_TEXT_MODEL_ID must be set when using an inference profile."
+                    )
+                identifier = quote(self.profile_id, safe="")
+                model = quote(self.model_id, safe="")
+                url = (
+                    f"https://bedrock-runtime.{self.aws_region}.amazonaws.com/"
+                    f"inference-profiles/{identifier}/model/{model}/invoke"
+                )
+            elif self.model_id:
+                identifier = quote(self.model_id, safe="")
+                url = (
+                    f"https://bedrock-runtime.{self.aws_region}.amazonaws.com/"
+                    f"model/{identifier}/invoke"
+                )
+            else:
+                raise RuntimeError(
+                    "Bedrock not configured: set BEDROCK_TEXT_MODEL_ID and optionally an inference profile",
+                )
+
+            if self.target_model_region:
+                url += f"?targetModelRegion={quote(self.target_model_region, safe='')}"
+
+            headers = {
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+                "x-api-key": self.api_key,
+            }
+            resp = requests.post(url, headers=headers, data=body_json)
+            resp.raise_for_status()
+            return resp.json()
+
         kwargs = self._build_invoke_kwargs(body_json)
         call_kwargs = {
             k: v

--- a/src/llm/service.py
+++ b/src/llm/service.py
@@ -4,7 +4,9 @@ from .bedrock_runtime import BedrockInvoker, format_user_message, extract_text
 
 load_dotenv()
 
-invoker = BedrockInvoker(aws_region=os.getenv("AWS_REGION"))
+invoker = BedrockInvoker(
+    aws_region=os.getenv("AWS_REGION"), api_key=os.getenv("BEDROCK_API_KEY")
+)
 
 def summarize_credit_profile(prompt: str) -> str:
     """


### PR DESCRIPTION
## Summary
- use BedrockInvoker for LLM calls in backend
- generate credit summaries via `summarize_credit_profile`
- reuse BedrockInvoker for `/similar_products` endpoint
- support Bedrock API key authentication
- send API key requests through inference profiles for higher throughput
- fall back to modelId when inference profiles are unsupported
- include modelId when invoking inference profiles

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68968f56e11883228df5b83d64baec74